### PR TITLE
Scale bomb arrow damage with player stats

### DIFF
--- a/src/main/kotlin/io/github/sharkzhs83/hardcore/Hardcore.kt
+++ b/src/main/kotlin/io/github/sharkzhs83/hardcore/Hardcore.kt
@@ -3,6 +3,9 @@ package io.github.sharkzhs83.hardcore
 import io.github.sharkzhs83.hardcore.arrows.Arrows
 import io.github.sharkzhs83.hardcore.events.Events
 import io.github.sharkzhs83.hardcore.level_scailing.Level_Scailing
+import io.github.sharkzhs83.hardcore.player_level.PlayerLevelScaling
+import io.github.sharkzhs83.hardcore.player_level.PlayerStatsCommand
+import io.github.sharkzhs83.hardcore.player_level.StatItemListener
 import org.bukkit.ChatColor
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
@@ -17,6 +20,11 @@ class Hardcore : JavaPlugin() , Listener{
         logger.info("HARDCORE has enabled")
         server.pluginManager.registerEvents(Events(), this)
         server.pluginManager.registerEvents(Level_Scailing(), this)
+        server.pluginManager.registerEvents(PlayerLevelScaling(this), this)
+        val statItemListener = StatItemListener(this)
+        server.pluginManager.registerEvents(statItemListener, this)
+        server.addRecipe(statItemListener.createRecipe())
+        getCommand("stats")?.setExecutor(PlayerStatsCommand(this))
         server.pluginManager.registerEvents(Arrows(), this)
         saveDefaultConfig()
 

--- a/src/main/kotlin/io/github/sharkzhs83/hardcore/arrows/Arrows.kt
+++ b/src/main/kotlin/io/github/sharkzhs83/hardcore/arrows/Arrows.kt
@@ -1,10 +1,12 @@
 package io.github.sharkzhs83.hardcore.arrows
 
 import org.bukkit.ChatColor
+import org.bukkit.Location
 import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
 import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
+import org.bukkit.entity.TNTPrimed
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.entity.EntityDamageByEntityEvent
@@ -23,18 +25,33 @@ class Arrows : Listener{
         }
     }
 
+    private fun spawnPlayerExplosion(loc: Location, player: Player) {
+        val tnt = loc.world.spawn(loc, TNTPrimed::class.java)
+        tnt.yield = 2f
+        tnt.fuseTicks = 0
+        tnt.source = player
+        tnt.sourceEntity = player
+    }
+
     @EventHandler
     fun onDamage(event: EntityDamageByEntityEvent) {
         if(event.damager.type == EntityType.ARROW && event.damager.isGlowing) {
-            event.entity.world.createExplosion(event.entity.location, 2f, true)
-            event.damager.remove()
+            val arrow = event.damager
+            val shooter = (arrow as? org.bukkit.entity.Arrow)?.shooter as? Player ?: return
+            spawnPlayerExplosion(event.entity.location, shooter)
+            arrow.remove()
         }
     }
 
     @EventHandler
     fun onDamage(event: ProjectileHitEvent) {
         if(event.entity.type == EntityType.ARROW && event.entity.isGlowing) {
-            event.entity.world.createExplosion(event.entity.location, 2f, true)
+            val shooter = (event.entity as org.bukkit.entity.Arrow).shooter as? Player
+            if (shooter != null) {
+                spawnPlayerExplosion(event.entity.location, shooter)
+            } else {
+                event.entity.world.createExplosion(event.entity.location, 2f, true)
+            }
             event.entity.remove()
         }
     }

--- a/src/main/kotlin/io/github/sharkzhs83/hardcore/player_level/PlayerLevelScaling.kt
+++ b/src/main/kotlin/io/github/sharkzhs83/hardcore/player_level/PlayerLevelScaling.kt
@@ -1,0 +1,104 @@
+package io.github.sharkzhs83.hardcore.player_level
+
+import net.kyori.adventure.text.Component
+import org.bukkit.attribute.Attribute
+import org.bukkit.configuration.file.FileConfiguration
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+import org.bukkit.entity.Projectile
+import org.bukkit.entity.TNTPrimed
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityDamageEvent
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerLevelChangeEvent
+import org.bukkit.plugin.java.JavaPlugin
+
+class PlayerLevelScaling(private val plugin: JavaPlugin) : Listener {
+
+    @EventHandler
+    fun onJoin(event: PlayerJoinEvent) {
+        initPlayer(event.player)
+        applyStats(event.player)
+    }
+
+    @EventHandler
+    fun onLevelChange(event: PlayerLevelChangeEvent) {
+        val diff = event.newLevel - event.oldLevel
+        if (diff > 0) {
+            val path = "players.${event.player.uniqueId}.points"
+            plugin.config.set(path, plugin.config.getInt(path) + diff)
+            plugin.saveConfig()
+            event.player.sendMessage(Component.text("스탯 포인트 $diff 획득!"))
+        }
+    }
+
+    @EventHandler
+    fun onDamage(event: EntityDamageEvent) {
+        if (event.entity !is Player) return
+        val player = event.entity as Player
+        val defense = plugin.config.getInt("players.${player.uniqueId}.defense")
+        if (defense > 0) {
+            event.damage *= (1 - defense * 0.05).coerceAtLeast(0.0)
+        }
+    }
+
+    @EventHandler
+    fun onAttack(event: EntityDamageByEntityEvent) {
+        val attacker: Player? = when (val damager = event.damager) {
+            is Player -> damager
+            is Projectile -> damager.shooter as? Player
+            is TNTPrimed -> damager.source as? Player ?: damager.sourceEntity as? Player
+            else -> null
+        }
+        attacker ?: return
+        val uuid = attacker.uniqueId
+        if (event.damager is Projectile) {
+            val bonus = plugin.config.getInt("players.$uuid.ranged")
+            event.damage += event.damage * bonus * 0.1
+        } else if (event.damager is TNTPrimed) {
+            val bonus = plugin.config.getInt("players.$uuid.explosive")
+            event.damage += event.damage * bonus * 0.1
+        }
+    }
+
+    private fun initPlayer(player: Player) {
+        val uuid = player.uniqueId
+        val cfg = plugin.config
+        val base = "players.$uuid"
+        if (!cfg.contains(base)) {
+            cfg.set("$base.points", 0)
+            cfg.set("$base.health", 0)
+            cfg.set("$base.melee", 0)
+            cfg.set("$base.ranged", 0)
+            cfg.set("$base.explosive", 0)
+            cfg.set("$base.speed", 0)
+            cfg.set("$base.defense", 0)
+            plugin.saveConfig()
+        }
+    }
+
+    fun applyStats(player: Player) {
+        applyStats(player, plugin.config)
+    }
+
+    companion object {
+        fun applyStats(player: Player, config: FileConfiguration) {
+            val base = "players.${player.uniqueId}"
+            val health = config.getInt("$base.health")
+            val melee = config.getInt("$base.melee")
+            val speed = config.getInt("$base.speed")
+            player.getAttribute(Attribute.GENERIC_MAX_HEALTH)?.let {
+                it.baseValue = 20.0 + health * 2
+                if (player.health > it.baseValue) player.health = it.baseValue
+            }
+            player.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE)?.let {
+                it.baseValue = 1.0 + melee * 0.5
+            }
+            player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)?.let {
+                it.baseValue = 0.1 + speed * 0.005
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/github/sharkzhs83/hardcore/player_level/PlayerStatsCommand.kt
+++ b/src/main/kotlin/io/github/sharkzhs83/hardcore/player_level/PlayerStatsCommand.kt
@@ -1,0 +1,33 @@
+package io.github.sharkzhs83.hardcore.player_level
+
+import net.kyori.adventure.text.Component
+import org.bukkit.command.Command
+import org.bukkit.command.CommandExecutor
+import org.bukkit.command.CommandSender
+import org.bukkit.command.TabCompleter
+import org.bukkit.entity.Player
+import org.bukkit.plugin.java.JavaPlugin
+
+class PlayerStatsCommand(private val plugin: JavaPlugin) : CommandExecutor {
+    override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
+        if (sender !is Player) {
+            sender.sendMessage("플레이어만 사용할 수 있습니다.")
+            return true
+        }
+        val uuid = sender.uniqueId.toString()
+        val cfg = plugin.config
+        if (command.name.equals("stats", true)) {
+            val msg = Component.text(
+                "남은 포인트: ${cfg.getInt("players.$uuid.points")} " +
+                        "체력: ${cfg.getInt("players.$uuid.health")} " +
+                        "근접: ${cfg.getInt("players.$uuid.melee")} " +
+                        "원거리: ${cfg.getInt("players.$uuid.ranged")} " +
+                        "폭발: ${cfg.getInt("players.$uuid.explosive")} " +
+                        "스피드: ${cfg.getInt("players.$uuid.speed")} " +
+                        "방어력: ${cfg.getInt("players.$uuid.defense")}")
+            sender.sendMessage(msg)
+            return true
+        }
+        return false
+    }
+}

--- a/src/main/kotlin/io/github/sharkzhs83/hardcore/player_level/StatItemListener.kt
+++ b/src/main/kotlin/io/github/sharkzhs83/hardcore/player_level/StatItemListener.kt
@@ -1,0 +1,101 @@
+package io.github.sharkzhs83.hardcore.player_level
+
+import net.kyori.adventure.text.Component
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.NamespacedKey
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.block.Action
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.InventoryHolder
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.ShapedRecipe
+import org.bukkit.persistence.PersistentDataType
+import org.bukkit.plugin.java.JavaPlugin
+
+class StatItemListener(private val plugin: JavaPlugin) : Listener {
+    private val itemKey = NamespacedKey(plugin, "stat_up_item")
+    private val typeKey = NamespacedKey(plugin, "stat_type")
+    private val holder = object : InventoryHolder {
+        private val inv = Bukkit.createInventory(this, 9, Component.text("스탯 강화"))
+        override fun getInventory(): Inventory = inv
+    }
+
+    fun createRecipe(): ShapedRecipe {
+        val item = createStatItem()
+        val key = NamespacedKey(plugin, "stat_tome")
+        val recipe = ShapedRecipe(key, item)
+        recipe.shape(" D ", "DBD", " D ")
+        recipe.setIngredient('D', Material.DIAMOND)
+        recipe.setIngredient('B', Material.BOOK)
+        return recipe
+    }
+
+    private fun createStatItem(): ItemStack {
+        val item = ItemStack(Material.BOOK)
+        val meta = item.itemMeta
+        meta.setDisplayName("Stat Tome")
+        meta.persistentDataContainer.set(itemKey, PersistentDataType.BYTE, 1)
+        item.itemMeta = meta
+        return item
+    }
+
+    private fun statOption(name: String, mat: Material): ItemStack {
+        val item = ItemStack(mat)
+        val meta = item.itemMeta
+        meta.setDisplayName(name)
+        meta.persistentDataContainer.set(typeKey, PersistentDataType.STRING, name)
+        item.itemMeta = meta
+        return item
+    }
+
+    private fun openGui(player: Player) {
+        val inv = Bukkit.createInventory(holder, 9, Component.text("스탯 강화"))
+        inv.setItem(0, statOption("health", Material.RED_DYE))
+        inv.setItem(1, statOption("melee", Material.IRON_SWORD))
+        inv.setItem(2, statOption("ranged", Material.BOW))
+        inv.setItem(3, statOption("explosive", Material.TNT))
+        inv.setItem(4, statOption("speed", Material.SUGAR))
+        inv.setItem(5, statOption("defense", Material.SHIELD))
+        player.openInventory(inv)
+    }
+
+    @EventHandler
+    fun onInteract(event: PlayerInteractEvent) {
+        if (event.action != Action.RIGHT_CLICK_AIR && event.action != Action.RIGHT_CLICK_BLOCK) return
+        val item = event.item ?: return
+        val meta = item.itemMeta ?: return
+        if (!meta.persistentDataContainer.has(itemKey, PersistentDataType.BYTE)) return
+        event.isCancelled = true
+        openGui(event.player)
+    }
+
+    @EventHandler
+    fun onClick(event: InventoryClickEvent) {
+        if (event.view.topInventory.holder !== holder) return
+        event.isCancelled = true
+        val player = event.whoClicked as? Player ?: return
+        val clicked = event.currentItem ?: return
+        val meta = clicked.itemMeta ?: return
+        val stat = meta.persistentDataContainer.get(typeKey, PersistentDataType.STRING) ?: return
+        val uuid = player.uniqueId
+        val cfg = plugin.config
+        val pointsPath = "players.$uuid.points"
+        val points = cfg.getInt(pointsPath)
+        if (points <= 0) {
+            player.sendMessage(Component.text("포인트가 부족합니다."))
+            return
+        }
+        cfg.set(pointsPath, points - 1)
+        val statPath = "players.$uuid.$stat"
+        cfg.set(statPath, cfg.getInt(statPath) + 1)
+        plugin.saveConfig()
+        PlayerLevelScaling.applyStats(player, plugin)
+        player.sendMessage(Component.text("$stat 스탯이 1 증가했습니다."))
+        player.closeInventory()
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,3 +4,7 @@ main: io.github.sharkzhs83.hardcore.Hardcore
 api-version: '1.21'
 libraries:
   - org.jetbrains.kotlin:kotlin-stdlib:2.1.10
+commands:
+  stats:
+    description: View your current stats
+    usage: /<command>


### PR DESCRIPTION
## Summary
- modify bomb arrow logic to spawn TNTPrimed owned by the shooter
- PlayerLevelScaling already boosts TNT explosion damage based on the explosive stat

## Testing
- `gradle build` *(fails: plugin dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6884a4e47de8832abc6676cba2e43688